### PR TITLE
Bugfix/kndp 38 website deploy removes helm charts index from gh pages

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -2,7 +2,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - bugfix/KNDP-38-Website-deploy-removes-Helm-charts-index-from-gh-pages
+      - release/*
 jobs:
   release:
     permissions:

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -2,7 +2,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - release/*
+      - bugfix/KNDP-38-Website-deploy-removes-Helm-charts-index-from-gh-pages
 jobs:
   release:
     permissions:

--- a/.github/workflows/docusaurus-deploy.yaml
+++ b/.github/workflows/docusaurus-deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - release/*
+      - bugfix/KNDP-38-Website-deploy-removes-Helm-charts-index-from-gh-pages
     
 defaults:
   run:

--- a/.github/workflows/docusaurus-deploy.yaml
+++ b/.github/workflows/docusaurus-deploy.yaml
@@ -33,5 +33,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
           publish_dir: /home/runner/work/kndp/kndp/website/build
+          destination_dir: website

--- a/.github/workflows/docusaurus-deploy.yaml
+++ b/.github/workflows/docusaurus-deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - bugfix/KNDP-38-Website-deploy-removes-Helm-charts-index-from-gh-pages
+      - release/*
     
 defaults:
   run:

--- a/packages/kndp/charts/kndp/Chart.yaml
+++ b/packages/kndp/charts/kndp/Chart.yaml
@@ -3,7 +3,7 @@ name: kndp
 description: A Helm chart for Kubernetes
 type: application
 
-version: 0.1.6
+version: 0.1.7
 
 appVersion: "1.16.0"
 


### PR DESCRIPTION
I added a new dir in gh-pages with website build, so the unnecessary files can be deleted