### PR TITLE
Bugfix/kndp 45 merge new created index with gh pages index

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -96,21 +96,21 @@ jobs:
           CR_SKIP_EXISTING: true
 
 
+      - name: Pulling last version of index.yaml 
+        working-directory: /home/runner/work/kndp/kndp/all-charts
+        run: curl -O -L "https://github.com/web-seven/kndp/raw/gh-pages/index.yaml"
 
 
-      - name: Create index.yaml
+      - name: Create index.yaml and merging with gh-pages index.yaml
         working-directory: /home/runner/work/kndp/kndp
         run: |
             if [ -d "all-charts" ]; then
-            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/"
+            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/" --merge /home/runner/work/kndp/kndp/all-charts/index.yaml
             cp all-charts/index.yaml /home/runner/work/kndp/kndp/website/build/
             else
               echo "No all-charts directory to create index.yaml, skipping"
             fi
-      - name: Pulling last version of index.yaml
-        working-directory: /home/runner/work/kndp/kndp/website/build
-        if: ${{ failure() }}
-        run: curl -O -L "https://github.com/web-seven/kndp/raw/gh-pages/index.yaml"
+            
 
       
       - name: create CNAME file with kndp.io domain

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -2,7 +2,7 @@ name: Release preaparation
 on:
   push:
     branches:
-      - bugfix/KNDP-45-merge-new-created-index-with-gh-pages-index
+      - release/*
 
 defaults:
   run:
@@ -35,7 +35,6 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@github.com"
-
       - name: Install Helm
         uses: azure/setup-helm@v3
         env:
@@ -50,7 +49,6 @@ jobs:
         id: metadata
         run: |
           git diff --name-only HEAD~1 HEAD | awk -F'/' 'NF >= 2 { print $1 "/" $2 }' | uniq > build.txt;
-
       - name: Build images
         id: build
         run: cat build.txt | xargs -I{} bash -c '[ -f {}/Dockerfile ] && docker build -t ${REGISTRY}/${{ github.repository }}/$(basename {}):${{ github.sha }} {} && docker push ${REGISTRY}/${{ github.repository }}/$(basename {}):${{ github.sha }} || true'
@@ -63,7 +61,6 @@ jobs:
         id: pack
         run: |
           cat build.txt | xargs -I{} bash -c '[ -d {}/charts -a ! -f {}/Dockerfile ] && chart_name=$(basename {}) && chart_version=$(cat {}/charts/*/Chart.yaml | grep version | awk '\''{print $2}'\'') && helm package {}/charts/${chart_name} -u -d ./all-charts/${chart_name}-${chart_version} || true'
-
       - name: Install dependencies
         run: npm install
 
@@ -105,12 +102,17 @@ jobs:
         working-directory: /home/runner/work/kndp/kndp
         run: |
             if [ -d "all-charts" ]; then
-            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/" --merge https://github.com/web-seven/kndp/blob/gh-pages/index.yaml
+            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/"
             cp all-charts/index.yaml /home/runner/work/kndp/kndp/website/build/
             else
               echo "No all-charts directory to create index.yaml, skipping"
             fi
-        
+      - name: Pulling last version of index.yaml
+        working-directory: /home/runner/work/kndp/kndp/website/build
+        if: ${{ failure() }}
+        run: curl -O -L "https://github.com/web-seven/kndp/raw/gh-pages/index.yaml"
+
+      
       - name: create CNAME file with kndp.io domain
         run: echo kndp.io > website/build/CNAME
       
@@ -119,4 +121,3 @@ jobs:
         with:
           github_token: ${{ secrets.ACCESS_TOKEN }}
           publish_dir: /home/runner/work/kndp/kndp/website/build
-

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -2,7 +2,7 @@ name: Release preaparation
 on:
   push:
     branches:
-      - release/*
+      - bugfix/KNDP-45-merge-new-created-index-with-gh-pages-index
 
 defaults:
   run:
@@ -105,7 +105,7 @@ jobs:
         working-directory: /home/runner/work/kndp/kndp
         run: |
             if [ -d "all-charts" ]; then
-            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/"
+            helm repo index all-charts --url "https://github.com/web-seven/kndp/releases/download/" --merge https://github.com/web-seven/kndp/blob/gh-pages/index.yaml
             cp all-charts/index.yaml /home/runner/work/kndp/kndp/website/build/
             else
               echo "No all-charts directory to create index.yaml, skipping"

--- a/packages/cluster-operator/Dockerfile
+++ b/packages/cluster-operator/Dockerfile
@@ -6,4 +6,4 @@ RUN CGO_ENABLED=0 go build -o /cluster-operator
 FROM alpine/k8s:1.24.16
 WORKDIR /
 COPY --from=build /cluster-operator /
-ENTRYPOINT [ "/cluster-operator" ]
+ENTRYPOINT [ "/cluster-operator" ] 

--- a/packages/stack-operator/Dockerfile
+++ b/packages/stack-operator/Dockerfile
@@ -10,3 +10,4 @@ COPY --from=build /operator /
 COPY --from=alpine/k8s:1.24.16 /usr/bin/kubectl /usr/local/bin/kubectl
 ENTRYPOINT [ "/operator" ]
 EXPOSE 8080
+ 


### PR DESCRIPTION
possible failure of building kndp Dockerfile,  it needs some files that exists only in other pr, also i resolved empty index.yaml issue and everytime workflow will not have charts or Dockerfiles to release, it will keep the last version of index.yaml from gh-pages